### PR TITLE
date: Implement date methods

### DIFF
--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -2,7 +2,7 @@
 
 use crate::{error::PlistError, unsafe_bindings, Plist, PlistType};
 use log::trace;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 const MAC_EPOCH: u64 = 978307200; // 01/01/2001
 
@@ -16,10 +16,8 @@ impl Plist {
     /// # Example
     /// ```rust
     /// use std::time::Duration;
-    /// let now = SystemTime::now()
-    ///    .duration_since(SystemTime::UNIX_EPOCH)
-    ///    .unwrap();
-    /// Plist::new_date(now);
+    /// let some_date = Plist::new_date(Duration::from_secs(1546635600));
+    /// let now: Plist = SystemTime::now().into();
     /// ```
     pub fn new_date(date: Duration) -> Plist {
         trace!("Generating new date plist");
@@ -56,6 +54,14 @@ impl Plist {
 impl From<Duration> for Plist {
     fn from(value: Duration) -> Self {
         Plist::new_date(value)
+    }
+}
+
+impl From<SystemTime> for Plist {
+    fn from(value: SystemTime) -> Self {
+        // unwrapping should be safe since UNIX_EPOCH
+        // is always lesser than SystemTime::now()
+        Plist::new_date(value.duration_since(SystemTime::UNIX_EPOCH).unwrap())
     }
 }
 

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -1,19 +1,102 @@
 // jkcoxson
 
-use std::time::SystemTime;
+use crate::{error::PlistError, unsafe_bindings, Plist, PlistType};
+use log::trace;
+use std::time::Duration;
 
-use crate::Plist;
+const MAC_EPOCH: u64 = 978307200; // 01/01/2001
 
 impl Plist {
-    /// Unimplemented
-    pub fn new_date(_date: SystemTime) -> Plist {
-        unimplemented!() // I am too tired to implement this right now
-                         // Turns out I'm too tired to impliment this ever
+    /// Returns a new plist with a date.
+    /// The duration must represent a time passed since the Unix Epoch.
+    ///
+    /// Note: the original library expects you to pass the number of seconds
+    /// since 01/01/2001 (Mac Epoch). You **don't** need to do this here.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::time::Duration;
+    /// let now = SystemTime::now()
+    ///    .duration_since(SystemTime::UNIX_EPOCH)
+    ///    .unwrap();
+    /// Plist::new_date(now);
+    /// ```
+    pub fn new_date(date: Duration) -> Plist {
+        trace!("Generating new date plist");
+        // The number of seconds since 01/01/2001
+        let duration = date - Duration::from_secs(MAC_EPOCH);
+        let secs = duration.as_secs();
+        let usecs = duration.as_micros() - (secs * 1000000) as u128;
+        unsafe { unsafe_bindings::plist_new_date(secs as i32, usecs as i32) }.into()
     }
-    pub fn get_date_val(&self) {
-        unimplemented!();
+
+    /// Returns a duration (a Unix Timestamp) of the date
+    pub fn get_date_val(&self) -> Result<Duration, PlistError> {
+        if self.plist_type != PlistType::Date {
+            return Err(PlistError::InvalidArg);
+        }
+        let mut sec = unsafe { std::mem::zeroed() };
+        let mut usec = unsafe { std::mem::zeroed() };
+        trace!("Getting date value");
+        unsafe { unsafe_bindings::plist_get_date_val(self.plist_t, &mut sec, &mut usec) };
+        let date = usec as u64 + (sec as u64) * 1000000;
+        Ok(Duration::from_micros(date) + Duration::from_secs(MAC_EPOCH))
     }
-    pub fn set_date_val(&self) {
-        unimplemented!();
+
+    /// Sets the date with a Unix Timestamp
+    pub fn set_date_val(&self, date: Duration) {
+        let duration = date - Duration::from_secs(MAC_EPOCH);
+        let secs = duration.as_secs();
+        let usecs = duration.as_micros() - (secs * 1000000) as u128;
+        trace!("Setting date value");
+        unsafe { unsafe_bindings::plist_set_date_val(self.plist_t, secs as i32, usecs as i32) };
+    }
+}
+
+impl From<Duration> for Plist {
+    fn from(value: Duration) -> Self {
+        Plist::new_date(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn check_unix_mac_date() {
+        let timestamp = 1546635600123456; // Jan 04 2019 21:00:00.123456
+
+        let unix_date = Duration::from_micros(timestamp);
+        let unix_plist = Plist::new_date(unix_date);
+
+        let secs = 1546635600 - MAC_EPOCH;
+        let usecs = 123456;
+
+        let mac_plist: Plist = unsafe {
+            unsafe_bindings::plist_new_date(secs as i32, usecs)
+        }.into();
+
+        assert_eq!(
+            unix_plist.get_date_val().unwrap(),
+            mac_plist.get_date_val().unwrap()
+        );
+    }
+
+    #[test]
+    fn set_random_date() {
+        let timestamp = 1546635600123456; // Jan 04 2019 21:00:00.123456
+
+        let date = Duration::from_micros(timestamp);
+        let plist = Plist::new_date(
+            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap()
+        ); // create a new date with a current time
+        plist.set_date_val(date); // set a new time
+
+        assert_eq!(
+            date,
+            plist.get_date_val().unwrap()
+        );
     }
 }


### PR DESCRIPTION
Implement `new_date`, `get_date_val` and `set_date_val` methods.

When creating a date the original library expects one to pass the number of seconds since 01/01/2001 (Mac Epoch). Since it's not obvious and we're quite used to standard Unix Timestamps instead, these methods automatically convert dates to Mac Epoch format (just like the `plist` Rust library does).

Both `set_date_val` method and `set_random_date` test currently panics with an assertion failure due to a [`libplist` bug](https://github.com/libimobiledevice/libplist/issues/264).