### PR TITLE
array: Fix UB in array_get_item

### DIFF
--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -24,7 +24,10 @@ impl Plist {
             return Err(PlistError::InvalidArg);
         }
         trace!("Getting array item");
-        Ok(unsafe { unsafe_bindings::plist_array_get_item(self.plist_t, index) }.into())
+        let mut plist: Plist = unsafe { unsafe_bindings::plist_array_get_item(self.plist_t, index) }.into();
+        plist.false_drop = true;
+
+        Ok(plist)
     }
     /// Gets the index of an array item
     pub fn array_get_item_index(&self) -> Result<u32, PlistError> {


### PR DESCRIPTION
Just like the `dict_get_item`, this one returns an item that's going to be dropped on the Rust side. This results in undefined behavior. To prevent this we set `false_drop`  property to true.

Even though the C function doesn't mention that we shouldn't free an item, I learned it the hard way with my test cases.