### PR TITLE
array: Add array_get_item_test 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "plist_plus"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "autotools",
  "bindgen",

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -97,4 +97,24 @@ mod tests {
         p.array_append_item(b).unwrap();
         assert!(p.array_get_item(0).unwrap().get_bool_val().unwrap());
     }
+
+    #[test]
+    fn array_get_item_test() {
+        // Create a new array with 3 items
+        let mut arr = Plist::new_array();
+        arr.array_append_item(Plist::new_string("1")).unwrap();
+        arr.array_append_item(Plist::new_string("2")).unwrap();
+        arr.array_append_item(Plist::new_string("3")).unwrap();
+
+        // Get items and immediately drop them
+        std::mem::drop(arr.array_get_item(0).unwrap());
+        std::mem::drop(arr.array_get_item(1).unwrap());
+        std::mem::drop(arr.array_get_item(2).unwrap());
+
+        // Check if the items are still present.
+        // They should be because we false drop them
+        assert_eq!("1", arr.array_get_item(0).unwrap().get_string_val().unwrap());
+        assert_eq!("2", arr.array_get_item(1).unwrap().get_string_val().unwrap());
+        assert_eq!("3", arr.array_get_item(2).unwrap().get_string_val().unwrap());
+    }
 }


### PR DESCRIPTION
This test checks if array items are *false* dropped. If they aren't (try removing `plist.false_drop = true` from the `array_get_item` function) the test panics, because the items are being freed. It shouldn't happen and we must be able to
get items as long as the array exists.